### PR TITLE
feat: add mini agent builder and architect

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
 # SnapplAppple
+
+This repository contains a simple Python utility for creating tiny AI agents.
+Use `agent_builder.py` to generate standalone agent scripts and
+`architect_agent.py` to run multiple agents together.
+
+## Usage
+
+```bash
+python agent_builder.py MyHelper "echoes input"
+python agent_builder.py MyOther "echoes input"
+python architect_agent.py "Hello" --dir .
+```

--- a/agent_builder.py
+++ b/agent_builder.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+import textwrap
+
+
+@dataclass
+class MiniAgent:
+    """A tiny agent that can perform very basic tasks."""
+
+    name: str
+    behavior: str
+
+    def run(self, prompt: str) -> str:
+        """Return a simple response based on the agent's behavior."""
+        return f"{self.name} ({self.behavior}) received: {prompt}"
+
+
+class AgentBuilder:
+    """Create new mini agents as standalone Python files."""
+
+    template = textwrap.dedent(
+        """\
+        from agent_builder import MiniAgent
+
+
+        class {class_name}(MiniAgent):
+            def __init__(self):
+                super().__init__(name="{name}", behavior="{behavior}")
+
+
+        if __name__ == "__main__":
+            agent = {class_name}()
+            print(agent.run("Hello"))
+        """
+    )
+
+    def build(self, name: str, behavior: str, directory: str = ".") -> Path:
+        """Generate a new mini agent file.
+
+        Args:
+            name: Name of the new agent class/file.
+            behavior: Short description of how the agent behaves.
+            directory: Where to write the new file.
+
+        Returns:
+            Path to the created Python file.
+        """
+        class_name = f"{name}Agent"
+        content = self.template.format(
+            class_name=class_name,
+            name=name,
+            behavior=behavior,
+        )
+        path = Path(directory) / f"{name.lower()}_agent.py"
+        path.write_text(content)
+        return path
+
+
+def _main() -> None:
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Build mini agents")
+    parser.add_argument("name", help="Name of the agent to create")
+    parser.add_argument("behavior", help="Behavior description")
+    parser.add_argument(
+        "--dir", default=".", help="Directory to place the generated agent file"
+    )
+    args = parser.parse_args()
+
+    builder = AgentBuilder()
+    path = builder.build(args.name, args.behavior, args.dir)
+    print(f"Created agent at {path}")
+
+
+if __name__ == "__main__":
+    _main()

--- a/architect_agent.py
+++ b/architect_agent.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from importlib import util
+from pathlib import Path
+from typing import List
+
+from agent_builder import MiniAgent
+
+
+class ArchitectAgent:
+    """Orchestrate multiple mini agents in a directory."""
+
+    def __init__(self, directory: str = ".") -> None:
+        self.directory = Path(directory)
+        self.agents: List[MiniAgent] = []
+        self._load_agents()
+
+    def _load_agents(self) -> None:
+        """Dynamically import all *_agent.py files and instantiate agents."""
+        for path in self.directory.glob("*_agent.py"):
+            spec = util.spec_from_file_location(path.stem, path)
+            if spec and spec.loader:
+                module = util.module_from_spec(spec)
+                spec.loader.exec_module(module)
+                for obj in module.__dict__.values():
+                    if (
+                        isinstance(obj, type)
+                        and issubclass(obj, MiniAgent)
+                        and obj is not MiniAgent
+                    ):
+                        self.agents.append(obj())
+
+    def run(self, prompt: str) -> list[str]:
+        """Run the prompt through all loaded agents."""
+        return [agent.run(prompt) for agent in self.agents]
+
+
+def _main() -> None:
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Run multiple mini agents")
+    parser.add_argument("prompt", help="Prompt to pass to the agents")
+    parser.add_argument(
+        "--dir", default=".", help="Directory containing generated agents"
+    )
+    args = parser.parse_args()
+
+    architect = ArchitectAgent(args.dir)
+    for response in architect.run(args.prompt):
+        print(response)
+
+
+if __name__ == "__main__":
+    _main()

--- a/test_architect_agent.py
+++ b/test_architect_agent.py
@@ -1,0 +1,14 @@
+from agent_builder import AgentBuilder
+from architect_agent import ArchitectAgent
+
+
+def test_architect_runs_agents(tmp_path):
+    builder = AgentBuilder()
+    builder.build("Alpha", "echoes", tmp_path)
+    builder.build("Beta", "echoes", tmp_path)
+
+    architect = ArchitectAgent(tmp_path)
+    responses = architect.run("ping")
+    assert len(responses) == 2
+    assert any("Alpha" in r for r in responses)
+    assert any("Beta" in r for r in responses)


### PR DESCRIPTION
## Summary
- add an ArchitectAgent to orchestrate generated mini agents
- document how to run multiple agents together
- test that architect loads and runs generated agents

## Testing
- `python -m py_compile agent_builder.py architect_agent.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a5a18995c48325833a411ffb33bb64