### PR TITLE
Add tests for agent builder and architect scripts

### DIFF
--- a/agent_builder.py
+++ b/agent_builder.py
@@ -1,0 +1,27 @@
+import argparse
+from pathlib import Path
+
+
+def build_agent(name: str, goal: str) -> Path:
+    """Create a simple agent file containing the goal.
+
+    Parameters
+    ----------
+    name: str
+        Name of the agent. The output file will be ``{name}.txt``.
+    goal: str
+        The text to write inside the file.
+    """
+    filename = Path(f"{name}.txt")
+    filename.write_text(f"Goal: {goal}\n")
+    return filename
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Create a basic agent file")
+    parser.add_argument("name", help="Name of the agent")
+    parser.add_argument("goal", help="Goal of the agent")
+    args = parser.parse_args()
+
+    path = build_agent(args.name, args.goal)
+    print(f"Built agent {args.name} at {path}")

--- a/architect_agent.py
+++ b/architect_agent.py
@@ -1,0 +1,19 @@
+import argparse
+from pathlib import Path
+
+
+def architect_agent(name: str, description: str) -> Path:
+    """Create a file representing an architected agent."""
+    filename = Path(f"{name}_architecture.txt")
+    filename.write_text(f"Description: {description}\n")
+    return filename
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Architect an agent")
+    parser.add_argument("name", help="Name of the architecture")
+    parser.add_argument("description", help="Description of the architecture")
+    args = parser.parse_args()
+
+    path = architect_agent(args.name, args.description)
+    print(f"Architected agent {args.name} at {path}")

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -1,0 +1,35 @@
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_agent_builder_creates_file(tmp_path):
+    script = Path(__file__).resolve().parent.parent / "agent_builder.py"
+    result = subprocess.run(
+        [sys.executable, str(script), "sample", "do things"],
+        capture_output=True,
+        text=True,
+        cwd=tmp_path,
+        check=True,
+    )
+    expected_file = tmp_path / "sample.txt"
+    assert expected_file.exists()
+    assert expected_file.read_text() == "Goal: do things\n"
+    assert "Built agent sample" in result.stdout
+    expected_file.unlink()
+
+
+def test_architect_agent_creates_file(tmp_path):
+    script = Path(__file__).resolve().parent.parent / "architect_agent.py"
+    result = subprocess.run(
+        [sys.executable, str(script), "blueprint", "great agent"],
+        capture_output=True,
+        text=True,
+        cwd=tmp_path,
+        check=True,
+    )
+    expected_file = tmp_path / "blueprint_architecture.txt"
+    assert expected_file.exists()
+    assert expected_file.read_text() == "Description: great agent\n"
+    assert "Architected agent blueprint" in result.stdout
+    expected_file.unlink()


### PR DESCRIPTION
## Summary
- Implement simple `agent_builder.py` and `architect_agent.py` scripts that create agent files and echo results
- Add pytest tests invoking scripts via `subprocess.run`, verifying file creation and output

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5a6dc76548325a200db6763c11a6f